### PR TITLE
Remove findbugs plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,23 +87,6 @@
             </plugins>
         </pluginManagement>
         <plugins>
-            <!-- FindBugs -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <effort>Max</effort>
-                    <threshold>Low</threshold>
-                    <xmlOutput>true</xmlOutput>
-                </configuration>
-            </plugin>
             <!-- Maven Bundle plugin -->
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
If built with -Dskip-sources-validation, the build will fail because of findbugs. It needs to remove findbugs plugin declaration here, as it is only needed in che-parent